### PR TITLE
Add errors to input form

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -29,6 +29,7 @@
     "react": "^16.13.1",
     "react-cytoscapejs": "^1.2.1",
     "react-dom": "^16.13.1",
+    "react-hook-form": "^6.12.2",
     "react-redux": "^7.2.2",
     "react-scripts": "3.4.3",
     "redux": "^4.0.5",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -29,7 +29,6 @@
     "react": "^16.13.1",
     "react-cytoscapejs": "^1.2.1",
     "react-dom": "^16.13.1",
-    "react-hook-form": "^6.12.2",
     "react-redux": "^7.2.2",
     "react-scripts": "3.4.3",
     "redux": "^4.0.5",

--- a/packages/frontend/src/PortalForm/index.tsx
+++ b/packages/frontend/src/PortalForm/index.tsx
@@ -150,6 +150,7 @@ const MappingBar = () => {
         <div className={styles.mappingBar}>
           <div className={styles.row}>
             <ZoneSearch
+              error={getError('from', errors)}
               value={from}
               update={setFrom}
               label="From"
@@ -158,6 +159,7 @@ const MappingBar = () => {
           </div>
           <div className={styles.row}>
             <ZoneSearch
+              error={getError('to', errors)}
               value={to}
               update={setTo}
               label="To"

--- a/packages/frontend/src/PortalForm/index.tsx
+++ b/packages/frontend/src/PortalForm/index.tsx
@@ -1,3 +1,4 @@
+import cn from 'clsx'
 import clone from 'lodash/cloneDeep'
 import React, {
   FormEvent,
@@ -16,6 +17,7 @@ import { PortalSize, Zone } from '@portaler/types'
 import { DEFAULT_PORTAL_SIZE, DEFAULT_ZONE } from '../common/data/constants'
 import useZoneListSelector from '../common/hooks/useZoneListSelector'
 import { RootState } from '../reducers'
+import { InputError } from '../types'
 import UserSettings from '../UserSettings'
 import ZoneSearch from '../ZoneSearch'
 import PortalSizeSelector from './PortalSizeSelector'
@@ -23,6 +25,46 @@ import styles from './styles.module.scss'
 import useAddPortal from './useAddPortal'
 
 const portalSizeValid = (size: PortalSize) => [0, 2, 7, 20].includes(size)
+
+const formValidator = (
+  from: Zone,
+  to: Zone,
+  portalSize: number,
+  hours: number | null,
+  minutes: number | null
+): InputError[] => {
+  const errors: InputError[] = []
+
+  if (from.id === DEFAULT_ZONE.id || !from) {
+    errors.push({ fieldName: 'from', errorText: 'Insert From Zone' })
+  }
+
+  if (to.id === DEFAULT_ZONE.id || !to) {
+    errors.push({ fieldName: 'to', errorText: 'Insert To Zone' })
+  }
+
+  if (portalSize !== 0) {
+    if (!minutes && !hours) {
+      errors.push({ fieldName: 'timer', errorText: 'Insert Time' })
+    }
+  }
+
+  return errors
+}
+
+const getError = (name: string, errors: InputError[]): string | null => {
+  if (!errors.length) {
+    return null
+  }
+
+  const errorVal = errors.find((e) => e.fieldName === name)
+
+  if (!errorVal) {
+    return null
+  }
+
+  return errorVal.errorText
+}
 
 const MappingBar = () => {
   const fromId = useSelector(
@@ -35,6 +77,7 @@ const MappingBar = () => {
   const [portalSize, setPortalSize] = useState<PortalSize>(DEFAULT_PORTAL_SIZE)
   const [hours, setHours] = useState<number | null>(null)
   const [minutes, setMinutes] = useState<number | null>(null)
+  const [errors, setErrors] = useState<InputError[]>([])
 
   const zones: Zone[] = useZoneListSelector()
 
@@ -61,6 +104,15 @@ const MappingBar = () => {
   const handleSubmit = useCallback(
     (e: FormEvent<HTMLFormElement>) => {
       e.preventDefault()
+
+      const err = formValidator(from, to, portalSize, hours, minutes)
+
+      if (err.length > 0) {
+        setErrors(err)
+        return
+      }
+
+      setErrors([])
 
       try {
         const hr = Number(hours)
@@ -120,9 +172,13 @@ const MappingBar = () => {
               <FormLabel component="legend">Time Left</FormLabel>
               <div className={styles.flexColumn}>
                 <TextField
+                  error={!!getError('timer', errors)}
+                  helperText={getError('timer', errors)}
                   disabled={portalSize === 0}
                   id="time-hour"
-                  className={styles.durationField}
+                  className={cn(styles.durationField, {
+                    [styles.disabled]: portalSize === 0,
+                  })}
                   type="number"
                   label="Hour(s)"
                   InputProps={{
@@ -132,9 +188,13 @@ const MappingBar = () => {
                   onChange={(e) => setHours(Number(e.currentTarget.value))}
                 />
                 <TextField
+                  error={!!getError('timer', errors)}
+                  helperText={getError('timer', errors)}
                   disabled={portalSize === 0}
                   id="time-minute"
-                  className={styles.durationField}
+                  className={cn(styles.durationField, {
+                    [styles.disabled]: portalSize === 0,
+                  })}
                   type="number"
                   label="Minute(s)"
                   InputProps={{

--- a/packages/frontend/src/PortalForm/styles.module.scss
+++ b/packages/frontend/src/PortalForm/styles.module.scss
@@ -12,6 +12,10 @@
 
 .durationField {
   width: 45%;
+
+  &.disabled {
+    opacity: 0.42;
+  }
 }
 
 .createBtn {

--- a/packages/frontend/src/ZoneSearch/index.tsx
+++ b/packages/frontend/src/ZoneSearch/index.tsx
@@ -15,16 +15,18 @@ interface ZoneSearchProps {
   zoneList: Zone[]
   label: string
   value: Zone
-  variant?: 'filled' | 'outlined' | 'standard'
   update: (zone: Zone) => void
+  variant?: 'filled' | 'outlined' | 'standard'
+  error?: string | null
 }
 
 const ZoneSearch: FC<ZoneSearchProps> = ({
   zoneList,
   label,
   value,
-  variant = 'standard',
   update,
+  variant = 'standard',
+  error = null,
 }) => {
   const acRef = useRef(null)
   const [currentZoneList, setCurrentZoneList] = useState<Zone[]>(zoneList)
@@ -73,7 +75,13 @@ const ZoneSearch: FC<ZoneSearchProps> = ({
       getOptionLabel={(o: Zone) => o.name}
       onChange={(_, val: Zone | null) => update(val ?? DEFAULT_ZONE)}
       renderInput={(params) => (
-        <TextField {...params} label={label} variant={variant as any} />
+        <TextField
+          {...params}
+          error={!!error}
+          helperText={error}
+          label={label}
+          variant={variant as any}
+        />
       )}
     />
   )

--- a/packages/frontend/src/types.ts
+++ b/packages/frontend/src/types.ts
@@ -1,0 +1,4 @@
+export interface InputError {
+  fieldName: string
+  errorText: string
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -10400,6 +10400,11 @@ react-error-overlay@^6.0.7:
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.0.8.tgz#474ed11d04fc6bda3af643447d85e9127ed6b5de"
   integrity sha512-HvPuUQnLp5H7TouGq3kzBeioJmXms1wHy9EGjz2OURWBp4qZO6AfGEcnxts1D/CbwPLRAgTMPCEgYhA3sEM4vw==
 
+react-hook-form@^6.12.2:
+  version "6.12.2"
+  resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-6.12.2.tgz#aa67f47da4730a7bce44768583bdf5b749eed521"
+  integrity sha512-O72E2DXyk7djFqyy6eYi5yESGweKe0CNHHPS0Mx4JazpLbE4Ox+66ldZ23f0J5ZN/krEjDWRD+hUfg5Shvfhtw==
+
 react-is@^16.12.0, react-is@^16.13.1, react-is@^16.7.0, react-is@^16.8.0, react-is@^16.8.1, react-is@^16.8.4:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"


### PR DESCRIPTION
Simple needed fix to add errors to the input form. 

I also tried to do a hack where I set an h6 that had opacity 0 to hopefully take the place of #23 but that didn't work for some reason and I didn't commit it here. What was supposed to be a quick and dirty little hacky fix, turned into a PitA. Might be worth looking into deeper if you're still interested in #23 @Tebro . I think doing it on the autocomplete will be too complicated for what it's worth. 

Squash and merge if you approve this. 